### PR TITLE
Fix image generation for gpt-image-1

### DIFF
--- a/podcast_generator.py
+++ b/podcast_generator.py
@@ -429,8 +429,7 @@ def generate_and_upload_cover_image(title, description, client, output_folder):
         prompt=image_prompt,
         n=1,
         size=IMAGE_SIZE,
-        quality=IMAGE_QUALITY,
-        response_format="url"
+        quality=IMAGE_QUALITY
     )
     image_url = intro_response.data[0].url
     logger.info(f"Image generated from {IMAGE_MODEL}: {image_url}")

--- a/wash_list.py
+++ b/wash_list.py
@@ -81,8 +81,7 @@ def generate_img_url(title, description):
         prompt=image_prompt,
         n=1,
         size=IMAGE_SIZE,
-        quality=IMAGE_QUALITY,
-        response_format="url"
+        quality=IMAGE_QUALITY
     )
 
     image_url = intro_response.data[0].url


### PR DESCRIPTION
## Summary
- remove `response_format="url"` because gpt-image-1 doesn't support it

## Testing
- `python -m py_compile podcast_generator.py wash_list.py`
- `pytest -q` *(no tests found)*